### PR TITLE
Allow "eybdoog" (goodbye backwards) goodbye messages

### DIFF
--- a/ouija.js
+++ b/ouija.js
@@ -23,7 +23,7 @@ const
 var
 	r = new snoowrap(config),
 	submissionId = process.argv[2],
-	goodbyeRegex = /^GOODBYE/,
+	goodbyeRegex = /^(GOODBYE|EYBDOOG)/,
 	link = /\[(.*?)\]\(.*?\)/g;
 
 // -------------- { MAIN } -----------------


### PR DESCRIPTION
Inspired by the thread https://redd.it/6ahndh

OP asks:
> ?sdrawkcab daer uoy nac
> (can you read backwards?)

to which Ouija responds:
> U O Y K C U F Eybdoog.
> (F U C K Y O U Goodbye.)

except that OuijaBot won't react to Eybdoog, so someone else had to
reply Goodbye so the bot would pick it up.

This commit will allow OuijaBot to respond to "eybdoog", so we never
have to suffer through something like this ever again.